### PR TITLE
Adding ETHOS-specific changes for Splunk Docker images

### DIFF
--- a/enterprise/Dockerfile-ethos
+++ b/enterprise/Dockerfile-ethos
@@ -1,0 +1,7 @@
+FROM splunk/splunk:6.5.0
+
+COPY ethos-entrypoint.sh /sbin/ethos-entrypoint.sh
+RUN chmod +x /sbin/ethos-entrypoint.sh
+
+ENTRYPOINT ["/sbin/ethos-entrypoint.sh"]
+CMD ["start-service"]

--- a/enterprise/ethos-entrypoint.sh
+++ b/enterprise/ethos-entrypoint.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+set -e
+
+if [ "$1" = 'splunk' ]; then
+  shift
+  sudo -HEu ${SPLUNK_USER} ${SPLUNK_HOME}/bin/splunk "$@"
+elif [ "$1" = 'start-service' ]; then
+  # If user changed SPLUNK_USER to root we want to change permission for SPLUNK_HOME
+  if [[ "${SPLUNK_USER}:${SPLUNK_GROUP}" != "$(stat --format %U:%G ${SPLUNK_HOME})" ]]; then
+    chown -R ${SPLUNK_USER}:${SPLUNK_GROUP} ${SPLUNK_HOME}
+  fi
+
+  # If version file exists already - this Splunk has been configured before
+  __configured=false
+  if [[ -f ${SPLUNK_HOME}/etc/splunk.version ]]; then
+    __configured=true
+  fi
+
+  __license_ok=false
+  # If these files are different override etc folder (possible that this is upgrade or first start cases)
+  # Also override ownership of these files to splunk:splunk
+  if ! $(cmp --silent /var/opt/splunk/etc/splunk.version ${SPLUNK_HOME}/etc/splunk.version); then
+    cp -fR /var/opt/splunk/etc ${SPLUNK_HOME}
+    chown -R ${SPLUNK_USER}:${SPLUNK_GROUP} ${SPLUNK_HOME}/etc
+    chown -R ${SPLUNK_USER}:${SPLUNK_GROUP} ${SPLUNK_HOME}/var
+  else
+    __license_ok=true
+  fi
+
+  if tty -s; then
+    __license_ok=true
+  fi
+
+  if [[ "$SPLUNK_START_ARGS" == *"--accept-license"* ]]; then
+    __license_ok=true
+  fi
+
+  if [[ $__license_ok == "false" ]]; then
+    cat << EOF
+Splunk Enterprise
+==============
+
+  Available Options:
+
+      - Launch container in Interactive mode "-it" to review and accept
+        end user license agreement
+      - If you have reviewed and accepted the license, start container
+        with the environment variable:
+            SPLUNK_START_ARGS=--accept-license
+
+  Usage:
+
+    docker run -it splunk/enterprise:6.4.1
+    docker run --env SPLUNK_START_ARGS="--accept-license" splunk/enterprise:6.4.1
+
+EOF
+    exit 1
+  fi
+
+  if [[ $__configured == "false" ]]; then
+    # If we have not configured yet allow user to specify some commands which can be executed before we start Splunk for the first time
+    if [[ -n ${SPLUNK_BEFORE_START_CMD} ]]; then
+      sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk ${SPLUNK_BEFORE_START_CMD}"
+    fi
+    for n in {1..30}; do
+      if [[ -n $(eval echo \$\{SPLUNK_BEFORE_START_CMD_${n}\}) ]]; then
+        sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk $(eval echo \$\{SPLUNK_BEFORE_START_CMD_${n}\})"
+      else
+        # We do not want to iterate all, if one in the sequence is not set
+        break
+      fi
+    done
+  fi
+
+  sudo -HEu ${SPLUNK_USER} ${SPLUNK_HOME}/bin/splunk start ${SPLUNK_START_ARGS}
+  trap "sudo -HEu ${SPLUNK_USER} ${SPLUNK_HOME}/bin/splunk stop" SIGINT SIGTERM EXIT
+
+  # If this is first time we start this splunk instance
+  if [[ $__configured == "false" ]]; then
+    __restart_required=false
+
+    # Setup deployment server
+    if [[ ${SPLUNK_ENABLE_DEPLOY_SERVER} == "true" ]]; then
+      sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk enable deploy-server -auth admin:changeme"
+      __restart_required=true
+    fi
+
+    # Setup deployment client
+    # http://docs.splunk.com/Documentation/Splunk/latest/Updating/Configuredeploymentclients
+    if [[ -n ${SPLUNK_DEPLOYMENT_SERVER} ]]; then
+      sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk set deploy-poll ${SPLUNK_DEPLOYMENT_SERVER} -auth admin:changeme"
+      __restart_required=true
+    fi
+
+    if [[ "$__restart_required" == "true" ]]; then
+      sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk restart"
+    fi
+
+    # Setup listening
+    # http://docs.splunk.com/Documentation/Splunk/latest/Forwarding/Enableareceiver
+    if [[ -n ${SPLUNK_ENABLE_LISTEN} ]]; then
+      sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk enable listen ${SPLUNK_ENABLE_LISTEN} -auth admin:changeme ${SPLUNK_ENABLE_LISTEN_ARGS}"
+    fi
+
+    # Setup forwarding server
+    # http://docs.splunk.com/Documentation/Splunk/latest/Forwarding/Deployanixdfmanually
+    if [[ -n ${SPLUNK_FORWARD_SERVER} ]]; then
+      sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk add forward-server ${SPLUNK_FORWARD_SERVER} -auth admin:changeme ${SPLUNK_FORWARD_SERVER_ARGS}"
+    fi
+    for n in {1..10}; do
+      if [[ -n $(eval echo \$\{SPLUNK_FORWARD_SERVER_${n}\}) ]]; then
+        if [[ -n $(eval echo \$\{SPLUNK_FORWARD_SERVER_${n}_CERT\}) ]]; then
+          printenv SPLUNK_FORWARD_SERVER_${n}_CERT > /opt/splunk/etc/SPLUNK_FORWARD_SERVER_${n}_CERT
+        fi
+        if [[ -n $(eval echo \$\{SPLUNK_FORWARD_SERVER_${n}_CA\}) ]]; then
+          printenv SPLUNK_FORWARD_SERVER_${n}_CA > /opt/splunk/etc/SPLUNK_FORWARD_SERVER_${n}_CA
+        fi
+        sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk add forward-server $(eval echo \$\{SPLUNK_FORWARD_SERVER_${n}\}) -auth admin:changeme $(eval echo \$\{SPLUNK_FORWARD_SERVER_${n}_ARGS\})"
+      else
+        # We do not want to iterate all, if one in the sequence is not set
+        break
+      fi
+    done
+
+    # Setup local HTTP Event Collector
+    if [[ -n ${SPLUNK_HEC_USESSL} ]]; then
+      sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk http-event-collector update -name http -uri https://localhost:8089 -disabled 0 -enable-ssl $(eval echo \$\{SPLUNK_HEC_USESSL\})"
+    fi
+    if [[ -n ${SPLUNK_HEC_USEJSON} ]]; then
+      sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk http-event-collector update -name http -uri https://localhost:8089 -disabled 0 -output-format json"
+    fi
+    for n in {1..10}; do
+      if [[ -n $(eval echo \${SPLUNK_HEC_${n}\}) ]]; then
+        sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk http-event-collector create new-token -name $(eval echo \$\{SPLUNK_HEC_${n}\}) -uri https://localhost:8089 -disabled 0 -outputgroup $(eval echo \$\{SPLUNK_HEC_${n}_OUTPUTGROUP\})"
+        if [[ -n $(eval echo \$\{SPLUNK_HEC_${n}_TOKEN\}) ]]; then
+          sudo -HEu ${SPLUNK_USER} sh -c "sed -i \"/$(eval echo \${SPLUNK_HEC_${n}\})/,/token = /{s/token = .*$/token = $(eval echo \$\{SPLUNK_HEC_${n}_TOKEN\})/}\" ${SPLUNK_HOME}/etc/apps/splunk_httpinput/local/inputs.conf"
+        fi
+      fi
+    done
+
+    # Setup monitoring
+    # http://docs.splunk.com/Documentation/Splunk/latest/Data/MonitorfilesanddirectoriesusingtheCLI
+    # http://docs.splunk.com/Documentation/Splunk/latest/Data/Monitornetworkports
+    if [[ -n ${SPLUNK_ADD} ]]; then
+        sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk add ${SPLUNK_ADD} -auth admin:changeme"
+    fi
+    for n in {1..30}; do
+      if [[ -n $(eval echo \$\{SPLUNK_ADD_${n}\}) ]]; then
+        sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk add $(eval echo \$\{SPLUNK_ADD_${n}\}) -auth admin:changeme"
+      else
+        # We do not want to iterate all, if one in the sequence is not set
+        break
+      fi
+    done
+
+    # Execute anything
+    if [[ -n ${SPLUNK_CMD} ]]; then
+        sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk ${SPLUNK_CMD}"
+    fi
+    for n in {1..30}; do
+      if [[ -n $(eval echo \$\{SPLUNK_CMD_${n}\}) ]]; then
+        sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk $(eval echo \$\{SPLUNK_CMD_${n}\})"
+      else
+        # We do not want to iterate all, if one in the sequence is not set
+        break
+      fi
+    done
+  fi
+
+  # Restart splunk to pick up any changes (HEC token overrides) that don't take immediate effect
+  sudo -HEu ${SPLUNK_USER} sh -c "${SPLUNK_HOME}/bin/splunk restart"
+
+  sudo -HEu ${SPLUNK_USER} tail -n 0 -f ${SPLUNK_HOME}/var/log/splunk/splunkd_stderr.log -f ${SPLUNK_HOME}/var/log/splunk/splunkd.log &
+  wait
+elif [ "$1" = 'splunk-bash' ]; then
+  sudo -u ${SPLUNK_USER} /bin/bash --init-file ${SPLUNK_HOME}/bin/setSplunkEnv
+else
+  "$@"
+fi


### PR DESCRIPTION
For the ETHOS-specific changes, I've added two files that can be used to create the ethos-splunkforwarder image:

The `Dockerfile-ethos` file just adds a different entrypoint file to the stock Splunk Docker image

The `ethos-entrypoint.sh` file is based off of the stock Splunk version, but has these additions:
- the SSL certs for forward-servers can be provided via environment variables and are exported onto the filesystem
- Up to 10 HEC endpoints can be configured via environment variables.
- The global HEC setting for SSL can be set via an environment variable

Examples:
    "SPLUNK_HEC_USESSL": "false",
    "SPLUNK_HEC_1_TOKEN": "blahblahblah",
    "SPLUNK_HEC_1": "ethos-hvc",
    "SPLUNK_HEC_1_OUTPUTGROUP": "splunk-us-hvc-internal.adobelaas.com_8200",
    "SPLUNK_HEC_2_TOKEN": "blahblahblahbooger",
    "SPLUNK_HEC_2": "ethos-lvc",
    "SPLUNK_HEC_2_OUTPUTGROUP": "splunk-us-lvc-internal.adobelaas.com_8200"