### PR TITLE
Update to version 6.5.2, adding enhanced metrics

### DIFF
--- a/enterprise/Dockerfile
+++ b/enterprise/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:jessie
 
 ENV SPLUNK_PRODUCT splunk
-ENV SPLUNK_VERSION 6.5.0
-ENV SPLUNK_BUILD 59c8927def0f
+ENV SPLUNK_VERSION 6.5.2
+ENV SPLUNK_BUILD 67571ef4b87d
 ENV SPLUNK_FILENAME splunk-${SPLUNK_VERSION}-${SPLUNK_BUILD}-Linux-x86_64.tgz
 
 ENV SPLUNK_HOME /opt/splunk
@@ -55,5 +55,5 @@ WORKDIR /opt/splunk
 # Configurations folder, var folder for everything (indexes, logs, kvstore)
 VOLUME [ "/opt/splunk/etc", "/opt/splunk/var" ]
 
-ENTRYPOINT ["/sbin/entrypoint.sh"]
+ENTRYPOINT ["/sbin/ethos-entrypoint.sh"]
 CMD ["start-service"]

--- a/enterprise/Dockerfile
+++ b/enterprise/Dockerfile
@@ -55,5 +55,5 @@ WORKDIR /opt/splunk
 # Configurations folder, var folder for everything (indexes, logs, kvstore)
 VOLUME [ "/opt/splunk/etc", "/opt/splunk/var" ]
 
-ENTRYPOINT ["/sbin/ethos-entrypoint.sh"]
+ENTRYPOINT ["/sbin/entrypoint.sh"]
 CMD ["start-service"]

--- a/enterprise/Dockerfile-ethos
+++ b/enterprise/Dockerfile-ethos
@@ -1,4 +1,4 @@
-FROM splunk/splunk:6.5.0
+FROM splunk/splunk:6.5.2
 
 COPY ethos-entrypoint.sh /sbin/ethos-entrypoint.sh
 RUN chmod +x /sbin/ethos-entrypoint.sh

--- a/enterprise/build.sh
+++ b/enterprise/build.sh
@@ -3,5 +3,5 @@ if [ -z $CURRENT ]; then
 	CURRENT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 fi
 
-docker build --no-cache=true -t splunk/splunk:6.5.0 $CURRENT
+docker build --no-cache=true -t splunk/splunk:6.5.2 $CURRENT
 #docker build -t splunk/splunk:latest $CURRENT


### PR DESCRIPTION
Changelog:
- modifications to allow for sending metrics.log and http event collector metrics to a user-specified remote index
  - changes to ethos-entrypoint.sh that set the hostname to include the cluster, the role, the zone, and the host IP in the server.conf's `serverName` parameter
- update to 6.5.2