### PR TITLE
Fixing splunk server hostname & adding http input queues

### DIFF
--- a/enterprise/Dockerfile-ethos
+++ b/enterprise/Dockerfile-ethos
@@ -1,5 +1,8 @@
 FROM splunk/splunk:6.5.2
 
+ENV SPLUNK_HEC_QUEUESIZE 500KB
+ENV SPLUNK_HEC_PERSISTENTQUEUESIZE 0
+
 COPY ethos-entrypoint.sh /sbin/ethos-entrypoint.sh
 RUN chmod +x /sbin/ethos-entrypoint.sh
 

--- a/enterprise/ethos-entrypoint.sh
+++ b/enterprise/ethos-entrypoint.sh
@@ -20,7 +20,7 @@ else
   zone=unknown
 fi
 
-SPLUNK_HOST="${MESOS_CLUSTER}_${ethos_role}_${zone}_${LIBPROCESS_IP}"
+SPLUNK_HOST="${MESOS_CLUSTER}_${ethos_role}_${zone}_${MARATHON_APP_ID}_${LIBPROCESS_IP}"
 
 if [ "$1" = 'splunk' ]; then
   shift


### PR DESCRIPTION
- adds memory and persistent input queues for http event collector
- adds the marathon app id to the hostname for easier identification